### PR TITLE
Add Wayland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,19 @@ WARNING: This might not be compliant way of doing things.
 `zstd`,
 ...
 
-Only **X**, Wayland is not supported.
+It is primarily tested on X, but (pure) Wayland support is there for
+Microsoft Edge, if the host has a Wayland session and active socket
+present. Please invoke Edge with
+
+```
+$ microsoft-edge --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WebRTCPipeWireCapturer
+```
+
+if you want the Wayland path. Sharing screen works under the browser
+realm with that (browser tab content). That is useful when the host
+itself is on Wayland, and anything X in the container image would mean
+XWayland translation on the host (with probably blurry images as a
+result).
 
 
 ## Install

--- a/mkosi.finalize
+++ b/mkosi.finalize
@@ -37,6 +37,7 @@ Bind=$_HOME/Downloads
 BindReadOnly=/run/pcscd/pcscd.comm
 BindReadOnly=/run/user/$SUDO_UID/pulse/native:/run/host_pulse_native
 BindReadOnly=/tmp/.X11-unix
+BindReadOnly=/run/user/$SUDO_UID/wayland-0:/run/host_wayland_0
 
 [Exec]
 Capability=all

--- a/mkosi.prepare
+++ b/mkosi.prepare
@@ -10,7 +10,11 @@ apt-get --yes --no-install-recommends install \
     intune-portal \
     libnss3-tools \
     microsoft-edge-stable \
-    opensc
+    opensc \
+    libwayland-client0 \
+    libwayland-cursor0 \
+    libwayland-egl1 \
+    libwayland-server0
 
 echo 'auth optional pam_gnome_keyring.so' \
     >> /etc/pam.d/common-auth

--- a/mkosi.skeleton/etc/profile.d/environment.sh
+++ b/mkosi.skeleton/etc/profile.d/environment.sh
@@ -1,4 +1,5 @@
 export DISPLAY=:0
 export PATH="/opt/microsoft/intune/bin:$PATH"
 export PULSE_SERVER=unix:/run/host_pulse_native
+export WAYLAND_DISPLAY=/run/host_wayland_0
 systemctl --user import-environment DISPLAY PATH PULSE_SERVER


### PR DESCRIPTION
Nothing like screen share tested yet with this, but at least Teams is there and functional. Flipping between X and Wayland might jeopardize the container's Intune registration (I lost it for reasons, the first time I manually went the Wayland route after having an image built and the second time around I went directly to Wayland-only, for Edge).

Random note: we should maybe add somewhere that mkosi up to version 13 work, but *not* 14. The fix might belong in mkosi itself or our repo.

Signed-off-by: Gustavo Lima Chaves <gustavo.chaves@microsoft.com>