### PR TITLE
Documentation update: minimal Debian and networking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ login and/or recommendation to install Intune and register your device.
 
 ## Networking
 
-Out-of-the-box systemd-nspawn expects you to use systemd-networkd and ideally systemd-resolved.
+Out-of-box systemd-nspawn expects you to use systemd-networkd and ideally systemd-resolved.
 This reduces bit of troubles when setting up container. Systemd ships with `/usr/lib/systemd/network/80-container-ve.network`
 for host side and `/usr/lib/systemd/network/80-container-host0.network` for container side network configuration.
 Although it still requires setting up minimal masquerading rule from user side.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ provided only for reference and with hope that it might be helpful. No
 warranties, be careful and review the code before you run it. **If you don't
 understand the code, then you shouldn't use it.**
 
+Minimum version of Debian which can be used is Bookworm (current testing).
+
 WARNING: This might not be compliant way of doing things.
 
 ## Dependencies
@@ -62,6 +64,18 @@ check if Edge profile status is "*Sync is on*" or you will be greeted with SSO
 login and/or recommendation to install Intune and register your device.
 
 ## Networking
+
+Out-of-the-box systemd-nspawn expects you to use systemd-networkd and ideally systemd-resolved.
+This reduces bit of troubles when setting up container. Systemd ships with `/usr/lib/systemd/network/80-container-ve.network`
+for host side and `/usr/lib/systemd/network/80-container-host0.network` for container side network configuration.
+Although it still requires setting up minimal masquerading rule from user side.
+
+Example with `nftables`:
+```
+$ nft add table nat
+$ nft 'add chain nat postrouting { type nat hook postrouting priority 100 ; }'
+$ nft add rule nat postrouting oifname "ve-corphost" masquerae
+```
 
 If you are using firewall (which is reasonable thing to do), then you have to allow traffic from `ve-*` interfaces.
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ login and/or recommendation to install Intune and register your device.
 
 ## Networking
 
-Networking configurations are very different and therefore cases here
-can be taken as generic guidance.
+Networking configurations could be very different and therefore cases here
+can be taken only as generic guidance.
 
 Out-of-box systemd-nspawn expects you to use `systemd-networkd` and ideally `systemd-resolved`.
 This reduces bit of troubles when setting up container. Systemd ships with `/usr/lib/systemd/network/80-container-ve.network`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ login and/or recommendation to install Intune and register your device.
 
 ## Networking
 
-Out-of-box systemd-nspawn expects you to use systemd-networkd and ideally systemd-resolved.
+Networking configurations are very different and therefore cases here
+can be taken as generic guidance.
+
+Out-of-box systemd-nspawn expects you to use `systemd-networkd` and ideally `systemd-resolved`.
 This reduces bit of troubles when setting up container. Systemd ships with `/usr/lib/systemd/network/80-container-ve.network`
 for host side and `/usr/lib/systemd/network/80-container-host0.network` for container side network configuration.
 Although it still requires setting up minimal masquerading rule from user side.
@@ -74,7 +77,7 @@ Example with `nftables`:
 ```
 $ nft add table nat
 $ nft 'add chain nat postrouting { type nat hook postrouting priority 100 ; }'
-$ nft add rule nat postrouting oifname "ve-corphost" masquerae
+$ nft add rule nat postrouting oifname "ve-corphost" masquerade
 ```
 
 If you are using firewall (which is reasonable thing to do), then you have to allow traffic from `ve-*` interfaces.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ login and/or recommendation to install Intune and register your device.
 Networking configurations could be very different and therefore cases here
 can be taken only as generic guidance.
 
+### Lazy approach
+
+Easiest option is to add `VirtualEthernet=no` to your corporate access
+container's `.nspawn` file, but with this you might run into problems if you
+have more nspawn containers running.
+
+### Harder but allows to have multiple containers
+
 Out-of-box systemd-nspawn expects you to use `systemd-networkd` and ideally `systemd-resolved`.
 This reduces bit of troubles when setting up container. Systemd ships with `/usr/lib/systemd/network/80-container-ve.network`
 for host side and `/usr/lib/systemd/network/80-container-host0.network` for container side network configuration.
@@ -94,10 +102,9 @@ table inet filter {
 ...
 ```
 
-Alternatively you can add `VirtualEthernet=no` to your corporate access
-container's `.nspawn` file, but with this you might run into problems if you
-have more nspawn containers running.
+### More information for inspiration
 
+[Systemd-nspawn networking](https://wiki.archlinux.org/title/Systemd-nspawn#Networking) in Arch Linux wiki.  
 See [`man systemd.nspawn`](https://www.freedesktop.org/software/systemd/man/systemd.nspawn.html) for details.
 
 ## Smartcard


### PR DESCRIPTION
Tested mkosi-intune with Bookworm - works without any additional packages from Sid.
Networking documentation updated with few lines about out-of-box approach.