### PR TITLE
Wayland reconcile, Document how to use cameras and VPN, and mention workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,21 @@ WARNING: This may not be the compliant way of doing things.
 `zstd`,
 ...
 
-Only **X**, for Wayland see [@glima](https://github.com/glima)'s [fork](https://github.com/glima/mkosi-intune).
+For X, X-Wayland or Wayland.
+
+NB: It is primarily tested on X, but (pure) Wayland support is there
+for Microsoft Edge, if the host has a Wayland session and active
+socket present.  That is useful when the host itself is on Wayland,
+and anything X in the container image would mean XWayland translation
+on the host (with probably blurry images as a result). If that is your
+use case, please invoke Edge with
+
+```
+$ microsoft-edge --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WebRTCPipeWireCapturer
+```
+
+if you want the Wayland path. Sharing screen has been seen to work for
+browser tabs, but is still very unstable--use at your own risk.
 
 ## Build & Install
 

--- a/README.md
+++ b/README.md
@@ -31,21 +31,34 @@ WARNING: This may not be the compliant way of doing things.
 `zstd`,
 ...
 
-For X, X-Wayland or Wayland.
+For X, X-Wayland or optionally Wayland.
 
 NB: It is primarily tested on X, but (pure) Wayland support is there
 for Microsoft Edge, if the host has a Wayland session and active
 socket present.  That is useful when the host itself is on Wayland,
 and anything X in the container image would mean XWayland translation
-on the host (with probably blurry images as a result). If that is your
-use case, please invoke Edge with
+on the host (with probably blurry images as a result).
+
+If that you want to use Wayland, please uncomment the lines in this repo
+prefixed with `#WAYLAND:` in `mkosi.finalize` and `mkosi.skeleton/etc/profile.d/mkosi.sh`:
+
+```
+sed -i 's/#WAYLAND: //g' mkosi.finalize mkosi.skeleton/etc/profile.d/mkosi.sh
+```
+
+Only then continue to build.
+
+Note: Inside the container, invoke Edge for Wayland with the `edge` alias or directly with
 
 ```
 $ microsoft-edge --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WebRTCPipeWireCapturer
 ```
 
-if you want the Wayland path. Sharing screen has been seen to work for
-browser tabs, but is still very unstable--use at your own risk.
+Sharing screen has been seen to work for browser tabs, but is still very unstable
+--use at your own risk.
+If Edge on Wayland crashes on screen sharing, make sure that it can't access the
+host X server (maybe you forgot to run `xhost -` after using the Intune portal?).
+A test can be done [here](https://webrtc.github.io/samples/src/content/getusermedia/getdisplaymedia/).
 
 ## Build & Install
 
@@ -62,7 +75,8 @@ $ sudo make install
 $ sudo machinectl login corphost
 ```
 
-Initial password is `hello` and you **must** change it, restart the container
+Initial password is `hello` and you **must** change it, both with `passwd` and
+with `seahorse` for the GNOME session keyring (right click), restart the container
 and only then run `intune-portal`. Otherwise keyring initialization might fail.
 Additionally you **must** always login to the container (e.g. after host
 reboot) to unlock the keyring.
@@ -71,11 +85,58 @@ Run `microsoft-edge` to take deep dive into corporate resources, but first
 check if Edge profile status is "*Sync is on*" or you will be greeted with SSO
 login and/or recommendation to install Intune and register your device.
 
+Note: Intune is a bit fragile and sometimes it helps to click "Refresh" to become
+compliant. When it looks like one is logged out, it helps to restart the systemd
+services and run Edge/the portal again.
+There are both system and user services:
+```
+systemctl restart --user microsoft-identity-broker.service
+systemctl restart --user intune-agent.service
+systemctl restart microsoft-identity-device-broker.service
+
+```
+
+Note: When using the Wayland variant, first run `xhost +` on your host before running
+`intune-portal` (because the `XAUTHORITY` info isn't forwarded). Afterwards, run
+`xhost -` to revert to original permissions.
+
+## Cameras
+
+By default, no video cameras are passed into the container.
+Change the `mkosi.finalize` file to pass a particular video device in on container start.
+After installation, edit `/etc/systemd/nspawn/corphost.nspawn`.
+
+Note that the device must be present then or the nspawn won't start the container.
+Afterwards you could create the device as written [here](https://askubuntu.com/a/1068341)
+(or try your luck with `machinectl bind ... /dev/video0 --mkdir`).
+You can test you camera [here](https://webrtc.github.io/samples/src/content/devices/input-output/).
+
 ## Networking
 
 `VirtualEthernet=no` is used, which means that container has access to host
 network. This simplifies life if you are moving your laptop between different
 networks. YMMV.
+
+## VPN
+
+You can use `gp-saml-gui` to set up the internal VPN. As with Intune, you may
+need to do a retry to get it running.
+
+Here an example setup:
+```
+apt install openconnect gp-saml-gui
+cat $HOME/.gpssl.conf:
+openssl_conf = openssl_init
+[openssl_init]
+ssl_conf = ssl_sect
+[ssl_sect]
+system_default = system_default_sect
+[system_default_sect]
+Options = UnsafeLegacyRenegotiation
+
+# You may now start it with your gateway:
+# OPENSSL_CONF=$HOME/.gpssl.conf gp-saml-gui --clientos Windows --sudo-openconnect --gateway GATEWAY -- -b
+```
 
 ## Smartcard
 

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -31,7 +31,7 @@ Packages=
     libwayland-cursor0
     libwayland-egl1
     lsb-release
-    microsoft-edge-dev
+    microsoft-edge-stable
     opensc
     polkitd
     pulseaudio

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -27,8 +27,11 @@ Packages=
     intune-portal
     libnss3-tools
     libpam-gnome-keyring
+    libwayland-client0
+    libwayland-cursor0
+    libwayland-egl1
     lsb-release
-    microsoft-edge-stable
+    microsoft-edge-dev
     opensc
     polkitd
     pulseaudio

--- a/mkosi.finalize
+++ b/mkosi.finalize
@@ -3,14 +3,24 @@
 cat > "$OUTPUTDIR/$IMAGE_ID.nspawn" << EOF
 [Files]
 Bind=/dev/dri
+# Uncomment the wanted camera devices. They need to be present on
+# container start. Afterwards you could create them as written in
+# https://askubuntu.com/a/1068341
+#Bind=/dev/video0
+#Bind=/dev/video1
+#Bind=/dev/video2
+#Bind=/dev/video3
+#Bind=/dev/video4
+#Bind=/dev/video5
+#Bind=/dev/video6
 Bind=$_HOME/Desktop
 Bind=$_HOME/Documents
 Bind=$_HOME/Downloads
 BindReadOnly=/run/pcscd/pcscd.comm
 BindReadOnly=/run/user/$_UID/pulse/native:/run/host_pulse_native
 BindReadOnly=/tmp/.X11-unix
-BindReadOnly=/run/user/$_UID/wayland-0:/run/host_wayland_0
-BindReadOnly=/run/user/$_UID/pipewire-0:/run/host_pipewire_0
+#WAYLAND: BindReadOnly=/run/user/$_UID/wayland-0:/run/host_wayland_0
+#WAYLAND: BindReadOnly=/run/user/$_UID/pipewire-0:/run/host_pipewire_0
 
 [Exec]
 Capability=all

--- a/mkosi.finalize
+++ b/mkosi.finalize
@@ -9,6 +9,8 @@ Bind=$_HOME/Downloads
 BindReadOnly=/run/pcscd/pcscd.comm
 BindReadOnly=/run/user/$_UID/pulse/native:/run/host_pulse_native
 BindReadOnly=/tmp/.X11-unix
+BindReadOnly=/run/user/$_UID/wayland-0:/run/host_wayland_0
+BindReadOnly=/run/user/$_UID/pipewire-0:/run/host_pipewire_0
 
 [Exec]
 Capability=all

--- a/mkosi.skeleton/etc/profile.d/mkosi.sh
+++ b/mkosi.skeleton/etc/profile.d/mkosi.sh
@@ -1,10 +1,10 @@
 export DISPLAY=:0
 export PATH="/opt/microsoft/intune/bin:$PATH"
 export PULSE_SERVER=unix:/run/host_pulse_native
-export WAYLAND_DISPLAY=/run/host_wayland_0
-export PIPEWIRE_REMOTE=/run/host_pipewire_0
+#WAYLAND: export WAYLAND_DISPLAY=/run/host_wayland_0
+#WAYLAND: export PIPEWIRE_REMOTE=/run/host_pipewire_0
 
-alias edge='microsoft-edge-stable --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WebRTCPipeWireCapturer'
+#WAYLAND: alias edge='microsoft-edge-stable --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WebRTCPipeWireCapturer'
 systemctl --user import-environment DISPLAY PATH PULSE_SERVER WAYLAND_DISPLAY PIPEWIRE_REMOTE
 
 if ! systemctl -q --user is-active intune-agent.timer

--- a/mkosi.skeleton/etc/profile.d/mkosi.sh
+++ b/mkosi.skeleton/etc/profile.d/mkosi.sh
@@ -4,7 +4,7 @@ export PULSE_SERVER=unix:/run/host_pulse_native
 export WAYLAND_DISPLAY=/run/host_wayland_0
 export PIPEWIRE_REMOTE=/run/host_pipewire_0
 
-alias edge='microsoft-edge-dev --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WebRTCPipeWireCapturer'
+alias edge='microsoft-edge-stable --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WebRTCPipeWireCapturer'
 systemctl --user import-environment DISPLAY PATH PULSE_SERVER WAYLAND_DISPLAY PIPEWIRE_REMOTE
 
 if ! systemctl -q --user is-active intune-agent.timer

--- a/mkosi.skeleton/etc/profile.d/mkosi.sh
+++ b/mkosi.skeleton/etc/profile.d/mkosi.sh
@@ -1,8 +1,11 @@
 export DISPLAY=:0
 export PATH="/opt/microsoft/intune/bin:$PATH"
 export PULSE_SERVER=unix:/run/host_pulse_native
+export WAYLAND_DISPLAY=/run/host_wayland_0
+export PIPEWIRE_REMOTE=/run/host_pipewire_0
 
-systemctl --user import-environment DISPLAY PATH PULSE_SERVER
+alias edge='microsoft-edge-dev --enable-features=UseOzonePlatform --ozone-platform=wayland --enable-features=WebRTCPipeWireCapturer'
+systemctl --user import-environment DISPLAY PATH PULSE_SERVER WAYLAND_DISPLAY PIPEWIRE_REMOTE
 
 if ! systemctl -q --user is-active intune-agent.timer
 then


### PR DESCRIPTION
This picks the commit from https://github.com/glima/mkosi-intune, reverts to Edge Stable and then I added:

- Document how to use cameras and VPN, and mention workarounds
    
    This documents the changes I needed to get a working setup with Wayland,
    using cameras and the VPN.
    It reconciles the repo with
    https://github.com/glima/mkosi-intune by commenting wayland-only changes
    out and documenting how to enable them again.